### PR TITLE
Add "private file" flag?

### DIFF
--- a/bin/pushfile
+++ b/bin/pushfile
@@ -10,6 +10,7 @@ opts
   .usage('[options] <file ...>')
   .option('-u, --unique', 'Gives a unique hash for uploaded file.')
   .option('-c, --configure', 'Create a configuration file.')
+  .option('-p, --private', 'Makes the file, when pushed, private.')
   .option('-v, --version', 'Prints Version');
 
 opts
@@ -20,6 +21,7 @@ opts
     console.log('    $ pushfile <FILENAME>');
     console.log('    $ pushfile -v');
     console.log('    $ pushfile -c');
+    console.log('    $ pushfile -p');
     console.log('');
   });
 
@@ -31,7 +33,7 @@ if (opts.configure) {
   pushfile.createConfig();
 }
 else if (optsLength > 0) {
-  pushfile.pushfile(opts.args[0], unique=opts.unique);
+  pushfile.pushfile(opts.args[0], unique=opts.unique, privateACL=opts.private);
 } 
 else if (optsLength <= 0) {
   console.log("no filename...")

--- a/lib/pushfile.js
+++ b/lib/pushfile.js
@@ -34,7 +34,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 let hashfile = require('./hashfile');
 
-function pushfile(filename, unique) {
+function pushfile(filename, unique, privateACL) {
     let s3Bucket;
     let config;
     try {
@@ -58,10 +58,14 @@ function pushfile(filename, unique) {
     }
     hashfile.hash(filename, salt, newFilename => {
         let contentType = _mime2.default.lookup(filename);
+        let fileACL = 'public-read';
+        if (privateACL) {
+            fileACL = 'private';
+        }
         _fs2.default.readFile(filename, (err, fileBuffer) => {
             const params = {
                 Key: newFilename,
-                ACL: 'public-read',
+                ACL: fileACL,
                 Body: fileBuffer,
                 ContentType: contentType
             };

--- a/src/pushfile.es6
+++ b/src/pushfile.es6
@@ -7,7 +7,7 @@ import mime from 'mime';
 
 let hashfile = require('./hashfile');
 
-export function pushfile(filename, unique) {
+export function pushfile(filename, unique, privateACL) {
     let s3Bucket;
     let config;
     try {
@@ -31,10 +31,14 @@ export function pushfile(filename, unique) {
     }
     hashfile.hash(filename, salt, newFilename => {
         let contentType = mime.lookup(filename);
+        let fileACL = 'public-read'
+        if (privateACL) {
+          fileACL = 'private';
+        }
         fs.readFile(filename, (err, fileBuffer) => {
             const params = {
                 Key: newFilename,
-                ACL: 'public-read',
+                ACL: fileACL,
                 Body: fileBuffer,
                 ContentType: contentType
             };


### PR DESCRIPTION
With PR #9, files are now public by default. Not sure if we should allow people to push private files... would there be a use-case for this?