### PR TITLE
bumping packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+1.1.1
+---
+
+* Package updates
+    * Bump eslint-config-prettier to 6.3.0
+    * Bump hashids to 2.0.1 
+    * Bump rollup to 1.21.4
+    * Bump eslint-plugin-prettier to 3.1.1
+    * Bump @babel/cli to 7.6.2
+    * Bump aws-sdk to 2.537.0
+    * Bump @babel/core to 7.6.2
+    * Bump @babel/preset-env to 7.6.2
+    * Bump @babel/register to 7.6.2
+    * Bump rollup-plugin-terser to 5.1.2
+
 1.1.0
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pushfile",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pushfile",
   "preferGlobal": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Command line app that pushes a file to S3 and gives you a URL.",
   "main": "bin/pushfile",
   "bin": {


### PR DESCRIPTION
* Package updates
    * Bump eslint-config-prettier to 6.3.0
    * Bump hashids to 2.0.1
    * Bump rollup to 1.21.4
    * Bump eslint-plugin-prettier to 3.1.1
    * Bump @babel/cli to 7.6.2
    * Bump aws-sdk to 2.537.0
    * Bump @babel/core to 7.6.2
    * Bump @babel/preset-env to 7.6.2
    * Bump @babel/register to 7.6.2
    * Bump rollup-plugin-terser to 5.1.2
